### PR TITLE
Better install / inference shell script for macOS users

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Define common paths for Homebrew
+BREW_PATHS=(
+  "/usr/local/bin"
+  "/opt/homebrew/bin"
+)
+
 if [[ "$(uname)" == "Darwin" ]]; then
   # macOS specific env:
   export PYTORCH_ENABLE_MPS_FALLBACK=1
@@ -10,6 +16,89 @@ elif [[ "$(uname)" != "Linux" ]]; then
 fi
 
 requirements_file="requirements.txt"
+
+# Function to add a path to PATH
+add_to_path() {
+  echo "Homebrew found in $1, which is not in your PATH."
+  read -p "Do you want to add this path to your PATH? (y/n) " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Adding $1 to PATH..."
+
+    # Detect the shell and choose the right profile file
+    local shell_profile
+    if [[ $SHELL == *"/bash"* ]]; then
+      shell_profile="$HOME/.bashrc"
+      [[ ! -f "$shell_profile" ]] && shell_profile="$HOME/.bash_profile"
+    elif [[ $SHELL == *"/zsh"* ]]; then
+      shell_profile="$HOME/.zshrc"
+    else
+      echo "Unsupported shell. Please add the following line to your shell profile file manually:"
+      echo "export PATH=\"$PATH:$1\""
+      return
+    fi
+
+    # Add the export line to the shell profile file
+    echo "export PATH=\"$PATH:$1\"" >> "$shell_profile"
+
+    # Source the shell profile file
+    source "$shell_profile"
+  fi
+}
+
+# Check if Homebrew is in PATH
+if ! command -v brew &> /dev/null; then
+  # If not, check common paths for Homebrew
+  echo "Homebrew not found in PATH. Checking common paths..."
+  for path in "${BREW_PATHS[@]}"; do
+    if [[ -x "$path/brew" ]]; then
+      add_to_path "$path"
+    fi
+  done
+fi
+
+# Check again if Homebrew is in PATH
+if ! command -v brew &> /dev/null; then
+  echo "Homebrew still not found. Attempting to install..."
+  INSTALL_OUTPUT=$(/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)")
+fi
+
+# Verifying if Homebrew has been installed successfully
+if command -v brew &> /dev/null; then
+  echo "Homebrew installed successfully."
+else
+  echo "Homebrew installation failed."
+  exit 1
+fi
+
+# Extracting the commands to add Homebrew to the PATH
+PATH_COMMANDS=$(echo "$INSTALL_OUTPUT" | awk '/Next steps:/,/Further documentation:/' | grep 'eval')
+
+echo "Extracted commands to add Homebrew to the PATH:"
+
+IFS=$'\n' # Set the Internal Field Separator to a new line
+for cmd in $PATH_COMMANDS
+do
+    echo "$cmd"
+done
+
+# Asking the user if they want to execute them
+echo "Do you want to automatically add Homebrew to your PATH by executing the commands above? (y/n)"
+read -p "Are you sure you want to run these commands? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  IFS=$'\n' # Set the Internal Field Separator to a new line
+  for cmd in $PATH_COMMANDS
+  do
+    eval "$cmd"
+  done
+fi
+
+# Installing ffmpeg with Homebrew
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "Installing ffmpeg..."
+  brew install ffmpeg
+fi
 
 # Check if Python 3.8 is installed
 if ! command -v python3.8 &> /dev/null; then

--- a/run.sh
+++ b/run.sh
@@ -119,5 +119,23 @@ fi
 echo "Installing onnxruntime..."
 python3.8 -m pip install onnxruntime
 
+download_if_not_exists() {
+  local filename=$1
+  local url=$2
+  if [ ! -f "$filename" ]; then
+    echo "$filename does not exist, downloading..."
+    curl -# -L -o "$filename" "$url"
+    echo "Download finished."
+  else
+    echo "$filename already exists."
+  fi
+}
+
+# Check and download hubert_base.pt
+download_if_not_exists "hubert_base.pt" "https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/hubert_base.pt"
+
+# Check and download rmvpe.pt
+download_if_not_exists "rmvpe.pt" "https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/rmvpe.pt"
+
 # Run the main script
 python3.8 infer-web.py --pycmd python3.8


### PR DESCRIPTION
- Auto installs homebrew if necessary + adds to PATH if it hasn't already added
- Does the same for Python 3.8 as well as the ffmpeg CLI utility
- Still installs requirements from the req txt, except this time, it's forced to list packages properly (I think?) 
- Still ensures M1 GPU will work with MPS
- Additionally installs onnxruntime since its commented out on requirements for reasons I don't understand

Tested by me on an M1 Mac as well as @rxhulski, special thanks to him!

Torchcrepe may require you to download it externally (pip install torchcrepe may also work):
https://github.com/maxrmorrison/torchcrepe/archive/refs/heads/master.zip