### PR TITLE
Updated package ffmpeg to 0.3.1 (changed based on local installation)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ fairseq==0.12.2
 faiss-cpu==1.7.2
 fastapi==0.88.0
 ffmpeg-python==0.2.0
-ffmpy==0.0.3
+ffmpy==0.3.1
 filelock==3.10.0
 flatbuffers==23.5.9
 fonttools==4.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ executing==1.2.0
 fairseq==0.12.2
 faiss-cpu==1.7.2
 fastapi==0.88.0
-ffmpeg-python==0.2.0
+ffmpeg-python==0.1.18
 ffmpy==0.3.1
 filelock==3.10.0
 flatbuffers==23.5.9


### PR DESCRIPTION
Based on python3.9 conda environment , I have tried [Mangio-RVC-Fork](https://github.com/Mangio621/Mangio-RVC-Fork) getting this error below , so I have updated ffmpeg package version to 0.3.1 (latest) it has been resolved 

![image](https://github.com/Mangio621/Mangio-RVC-Fork/assets/97831658/62d7d3ee-cdf3-4e6e-b835-fff9d5e71b92)
![image](https://github.com/Mangio621/Mangio-RVC-Fork/assets/97831658/6c2005d9-f3c9-4258-ac54-3382a02e1978)
